### PR TITLE
Fix: Check for frontend build directory at startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware # CORSMiddlewareをインポート
@@ -13,6 +15,16 @@ from fastapi.responses import FileResponse
 from .logic.horoscope_calc import calculate_horoscope
 
 app = FastAPI()
+
+frontend_build_dir = "../../frontend/build"
+
+# Check if the frontend build directory exists
+if not os.path.isdir(frontend_build_dir):
+    sys.stderr.write(
+        f"Error: Frontend build directory not found at {frontend_build_dir}.\n"
+        "Please run 'cd frontend && npm run build' to build the frontend.\n"
+    )
+    sys.exit(1)
 
 # CORS設定
 origins = [
@@ -31,7 +43,7 @@ app.add_middleware(
 )
 
 # Serve static files from the frontend build directory
-app.mount("/static", StaticFiles(directory="../../frontend/build"), name="static")
+app.mount("/static", StaticFiles(directory=frontend_build_dir), name="static")
 
 class Birthdate(BaseModel):
     year: int


### PR DESCRIPTION
The application was crashing if the frontend build artifacts were missing. This change modifies `backend/app/main.py` to:
- Check for the existence of the `../../frontend/build` directory upon startup.
- If the directory is not found, print a clear error message to the console, instructing you to build the frontend (e.g., by running `npm run build` in the `frontend` directory).
- Exit gracefully if the directory is missing.

This prevents the `RuntimeError: Directory '../../frontend/build' does not exist` and provides better guidance to you.