### PR TITLE
Fix: Update property names in DetailedQuestionnaire components

### DIFF
--- a/frontend/src/components/DetailedQuestionnaire.tsx
+++ b/frontend/src/components/DetailedQuestionnaire.tsx
@@ -136,9 +136,9 @@ const DetailedQuestionnaire: React.FC = () => {
           )}
           <p>{result.baseDescription}</p>
           <h4>{result.variantTitle}</h4>
-          <p>{result.variantDescription}</p>
+          <p>{result.variant_description_sub_title_explanation}</p>
           <h4>{result.subTitle}</h4>
-          <p>{result.subDescription}</p>
+          <p>{result.sub_type_description_sub_title_explanation}</p>
         </div>
       </div>
     );


### PR DESCRIPTION
I've updated property names in DetailedQuestionnaire.tsx and DetailedQuestionnaire.test.tsx to align with the
changes in the DetailedFeatureInfo type definition.

- Renamed variantDescription to variant_description_sub_title_explanation
- Renamed subDescription to sub_type_description_sub_title_explanation

This should resolve the TS2551 build error.