### PR TITLE
Fix: Update title and video display, resolve ESLint warnings

### DIFF
--- a/frontend/src/constants/officialFeatures.ts
+++ b/frontend/src/constants/officialFeatures.ts
@@ -22,6 +22,7 @@ export interface FeatureInfo {
 export interface DetailedFeatureInfo {
   catch: string;
   baseDescription: string;
+  mainTypeNameJp?: string; // ★追加
   variantTitle: string;
   variant_description_sub_title_explanation: string; // 元の variantDescription
   variant_description_main?: string; // 新しく追加する解説文
@@ -104,6 +105,7 @@ export function getDetailedFeature(finalKey: string): DetailedFeatureInfo | null
   return {
     catch: (entry as any).new_catchphrase_jp,
     baseDescription: (entry as any).new_description_jp,
+    mainTypeNameJp: (entry as any).type_name_jp || (entry as any).jumeri_type_name_jp, // ★追加： entry.type_name_jp または entry.jumeri_type_name_jp を想定
     variantTitle: variantInfo.new_title_jp,
     variant_description_sub_title_explanation: variantInfo.new_description_jp,
     variant_description_main: variantInfo.variant_description,
@@ -115,4 +117,5 @@ export function getDetailedFeature(finalKey: string): DetailedFeatureInfo | null
   };
 }
 
-export default {};
+const defaultExport = {};
+export default defaultExport;

--- a/frontend/src/pages/Diagnose.tsx
+++ b/frontend/src/pages/Diagnose.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
-import { getInitialFeature } from "../constants/officialFeatures";
-import { ApiDiagnosis, FeatureInfo } from "../types";
+// import { getInitialFeature } from "../constants/officialFeatures"; // Removed
+import { ApiDiagnosis } from "../types"; // FeatureInfo removed
 
 /**
  * Birthdate form that triggers backend calculation and
@@ -14,14 +14,14 @@ function Diagnose() {
   const [year, setYear] = useState("");
   const [month, setMonth] = useState("");
   const [day, setDay] = useState("");
-  const [result, setResult] = useState<ApiDiagnosis | null>(null);
+  // const [result, setResult] = useState<ApiDiagnosis | null>(null); // Removed
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-    setResult(null);
+    // setResult(null); // Removed
     try {
       const res = await axios.post(`${process.env.REACT_APP_API_URL}/diagnose`, {
         year: parseInt(year),

--- a/frontend/src/pages/Personality.tsx
+++ b/frontend/src/pages/Personality.tsx
@@ -19,16 +19,26 @@ const Personality: React.FC = () => {
     return <div>特徴情報が見つかりません。</div>;
   }
 
+  // 新しいタイトル文字列を生成
+  const pageTitle = [
+    feature.mainTypeNameJp,
+    feature.variantTitle,
+    feature.subTitle
+  ].filter(Boolean).join(' '); // filter(Boolean)でundefinedや空文字を除外して連結
+
   return (
     <div className="personality-page-container">
       {/* タイトル */}
-      <h1 className="personality-title">{feature.catch}</h1>
+      <h1 className="personality-title">{pageTitle}</h1> {/* ★変更箇所 */}
 
       {/* 映像 */}
       <div className="video-player-section">
-        {/* Replace with actual video player component and logic */}
-        {/* <VideoPlayerComponent src={videoSrc} /> */}
-        <p><i>Video for {finalKey} would be here. Path: {videoSrc}</i></p>
+        {/* ★修正箇所 */}
+        <video controls width="100%" key={videoSrc}> {/* key={videoSrc} を追加して finalKey 変更時に動画を再読み込みさせる */}
+          <source src={videoSrc} type="video/mp4" />
+          お使いのブラウザは動画タグをサポートしていません。
+        </video>
+        {/* ★ここまで */}
       </div>
 
       {/* アクロニム */}


### PR DESCRIPTION
- Modified Personality.tsx to display a concatenated title of main type name, alpha/beta variant title, and 1/2 sub-type title.
- Replaced video placeholder in Personality.tsx with HTML5 <video> tag.
- Resolved ESLint warnings in officialFeatures.ts and Diagnose.tsx by removing unused imports/variables and modifying default export.
- Added mainTypeNameJp to DetailedFeatureInfo in officialFeatures.ts to support the new title format.