### PR TITLE
Fix: Improve UI of diagnostic result screen

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -195,3 +195,7 @@ label {
   }
 }
 
+/* Custom utility classes */
+.custom-margin-bottom-lg {
+  margin-bottom: 4rem !important; /* Using !important to ensure override if necessary */
+}

--- a/frontend/src/pages/Personality.tsx
+++ b/frontend/src/pages/Personality.tsx
@@ -168,9 +168,9 @@ const Personality: React.FC = () => {
       )}
 
       {/* ⑥ メイン部分の解説 */}
-      <section className="main-type-description-section section-padding mb-12">
+      <section className="main-type-description-section section-padding custom-margin-bottom-lg">
         <h2 className="section-title">基本特性</h2> {/* Changed from h3 and "解説" */}
-        <div className="description-text text-center">
+        <div className="description-text text-center" style={{ textAlign: 'center' }}>
           {feature.mainTypeDescription.split('\n').map((line, i) => (
             <React.Fragment key={i}>{line}<br /></React.Fragment>
           ))}
@@ -189,9 +189,9 @@ const Personality: React.FC = () => {
       </section>
 
       {/* ⑨ αかβ分類の解説 */}
-      <section className="alpha-beta-description-section section-padding mb-12">
+      <section className="alpha-beta-description-section section-padding custom-margin-bottom-lg">
         <h3 className="subsection-title">解説</h3> {/* Kept h3 as it's a subsection of α/β */}
-        <div className="description-text text-center">
+        <div className="description-text text-center" style={{ textAlign: 'center' }}>
           {feature.alphaBetaTypeDescription.split('\n').map((line, i) => (
             <React.Fragment key={i}>{line}<br /></React.Fragment>
           ))}
@@ -212,7 +212,7 @@ const Personality: React.FC = () => {
       {/* ⑫ 1型、Ⅱ型分類の解説 */}
       <section className="one-two-type-description-section section-padding">
         <h3 className="subsection-title">解説</h3> {/* Kept h3 as it's a subsection of 1/2 type */}
-        <div className="description-text text-center">
+        <div className="description-text text-center" style={{ textAlign: 'center' }}>
           {feature.oneTwoTypeDescription.split('\n').map((line, i) => (
             <React.Fragment key={i}>{line}<br /></React.Fragment>
           ))}


### PR DESCRIPTION
This commit addresses UI readability issues on the diagnostic result page:

- Increased vertical spacing:
    - Added more space (4rem) between the 'basic characteristics' explanation and the 'alpha/beta classification' title.
    - Added more space (4rem) between the 'alpha/beta classification' explanation and the 'type 1/2 classification' title. This was achieved by introducing a new CSS class `custom-margin-bottom-lg` and applying it to the relevant sections.

- Ensured text alignment:
    - Center-aligned the explanation text for 'main', 'alpha/beta classification', and 'type 1/2 classification' sections by adding inline `textAlign: 'center'` styles to the description text containers.