### PR TITLE
Refactor(layout): 結果ページのレイアウト調整

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -195,6 +195,15 @@ label {
   }
 }
 
+/* Page-specific title styles */
+.personality-main-title {
+  font-size: clamp(2.5rem, 5vw, 4rem); /* Responsive font size */
+  text-align: center; /* Ensure center alignment */
+  line-height: 1.2; /* Adjust line height for larger font */
+  margin-bottom: 1rem; /* Space before video */
+  word-break: keep-all; /* Prevent awkward breaks in Japanese titles */
+}
+
 /* Custom utility classes */
 .custom-margin-bottom-lg {
   margin-bottom: 4rem !important; /* Using !important to ensure override if necessary */

--- a/frontend/src/pages/Personality.tsx
+++ b/frontend/src/pages/Personality.tsx
@@ -131,11 +131,6 @@ const Personality: React.FC = () => {
         <h2 className="section-title">{feature.mainTypeTitle}</h2>
       </section>
 
-      {/* ④ メイン部分（12タイプ）のキャッチコピー (タイトルから抽出) */}
-      <section className="main-type-extracted-catchphrase-section section-padding"> {/* Changed class name */}
-        <p className="catchphrase-text">{extractActualCatchphrase(feature.mainTypeTitle)}</p>
-      </section>
-
       {/* ⑤ アクロニム */}
       {feature.mainTypeAcronyms && (
         <section className="acronym-section section-padding">


### PR DESCRIPTION
あなたのフィードバックに基づき、診断結果ページ (`Personality.tsx`) のレイアウトを調整しました。

主な変更点:
1. メインタイトルのスタイル変更:
   - `.personality-main-title` (h1要素) のフォントサイズを拡大し、レスポンシブに対応させました (`font-size: clamp(2.5rem, 5vw, 4rem);`)。
   - テキストが中央揃えで表示され、適切な行間とマージンが設定されるようにしました。
   - `word-break: keep-all;` を設定し、日本語タイトルが不自然に改行されるのを抑制しました。 これらのスタイルは `frontend/src/index.css` に追加されました。

2. 重複キャッチコピーの削除:
   - 動画の下に表示されていたメインタイプのキャッチコピー (`main-type-extracted-catchphrase-section`) を削除しました。
   - これにより、メインタイプ名（角括弧付き）の下に同じ内容のキャッチコピー（角括弧なし）が重複して表示される問題が解消されました。