### PR TITLE
Fix: Update video playback speed logic and add new speed

### DIFF
--- a/frontend/src/pages/Personality.tsx
+++ b/frontend/src/pages/Personality.tsx
@@ -86,18 +86,33 @@ const Personality: React.FC = () => {
         setVideoSrc(newVideoSrc);
 
         if (videoRef.current) {
-          if (videoRef.current.src !== newVideoSrc) {
-            videoRef.current.load(); // Load new video source
-          }
-          // Set playback speed based on finalKey
-          // const formattedKey = formatKeyForVideo(finalKey); // videoMapKey can be reused
-          if (videoMapKey === "MARI_ALPHA_2") {
-            videoRef.current.playbackRate = 2.0;
-          } else if (videoMapKey === "MARI_BETA_1") {
-            videoRef.current.playbackRate = 1.7;
-          } else {
-            videoRef.current.playbackRate = 1.0;
-          }
+            let targetPlaybackRate = 1.0;
+            if (videoMapKey === "MARI_ALPHA_2") {
+                targetPlaybackRate = 2.0;
+            } else if (videoMapKey === "MARI_BETA_1") {
+                targetPlaybackRate = 1.7;
+            } else if (videoMapKey === "SENRI_ALPHA_2") { // New case for Senri α-2
+                targetPlaybackRate = 1.5;
+            }
+
+            const videoElement = videoRef.current;
+
+            const applyRate = () => {
+                // Check if the rate actually needs changing to avoid unnecessary operations
+                if (videoElement.playbackRate !== targetPlaybackRate) {
+                    videoElement.playbackRate = targetPlaybackRate;
+                }
+            };
+
+            if (videoElement.readyState >= 2) { // HAVE_CURRENT_DATA
+                applyRate();
+            } else {
+                const onLoadedDataListener = () => {
+                    applyRate();
+                    videoElement.removeEventListener('loadeddata', onLoadedDataListener); // Clean up
+                };
+                videoElement.addEventListener('loadeddata', onLoadedDataListener);
+            }
         }
       }
     }


### PR DESCRIPTION
This commit addresses issues with your video playback speed settings and introduces a new speed modification:

1.  **Robust Playback Speed Setting:**
    *   Modified `frontend/src/pages/Personality.tsx` to improve the reliability of setting video playback speeds.
    *   The logic now checks the video's `readyState` and uses a `loadeddata` event listener to ensure the playback rate is applied after the video data is available. This should fix issues where speed changes were not consistently applied.

2.  **Updated Playback Speeds:**
    *   Ensured MARI α-2 (MARI_ALPHA_2) video playback speed is set to 2.0x.
    *   Ensured Mari β-1 (MARI_BETA_1) video playback speed is set to 1.7x.

3.  **New Playback Speed:**
    *   Added logic to set Senri α-2 (SENRI_ALPHA_2) video playback speed to 1.5x as per new requirements.