### PR TITLE
Add playback rate helper

### DIFF
--- a/frontend/src/components/DetailedQuestionnaire.tsx
+++ b/frontend/src/components/DetailedQuestionnaire.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import questionsData from '../constants/questions.json';
 import { getDetailedFeature } from '../constants/officialFeatures';
 import { getVideoFileForCategory } from '../constants/videoMap';
+import { getPlaybackRateForCategory } from '../constants/videoPlayback';
 import { Question, DetailedDiagnosisResult, DetailedFeatureInfo } from '../types';
 
 /**
@@ -44,20 +45,7 @@ const DetailedQuestionnaire: React.FC = () => {
   // Update playback rate based on result key
   useEffect(() => {
     if (result) {
-      const key = result.category
-        .replace(/\s+/g, '')
-        .replace('α', 'ALPHA')
-        .replace('β', 'BETA')
-        .replace('-', '_')
-        .replace('ー', '_')
-        .replace('–', '_')
-        .toUpperCase();
-      let rate = 1;
-      if (key === 'MARI_ALPHA_2' || key === 'SENRI_ALPHA_2') {
-        rate = 1.5;
-      } else if (key === 'MARI_BETA_1') {
-        rate = 1.3;
-      }
+      const rate = getPlaybackRateForCategory(result.category);
       setPlaybackRate(rate);
     }
   }, [result]);

--- a/frontend/src/constants/videoPlayback.ts
+++ b/frontend/src/constants/videoPlayback.ts
@@ -1,0 +1,17 @@
+export const VIDEO_PLAYBACK_RATE: Record<string, number> = {
+  'MARI_ALPHA_2': 1.5,
+  'MARI_BETA_1': 1.3,
+  'SENRI_ALPHA_2': 1.5,
+};
+
+export function getPlaybackRateForCategory(category: string): number {
+  const key = category
+    .replace(/\s+/g, '')
+    .replace('α', 'ALPHA')
+    .replace('β', 'BETA')
+    .replace('-', '_')
+    .replace('ー', '_')
+    .replace('–', '_')
+    .toUpperCase();
+  return VIDEO_PLAYBACK_RATE[key] || 1;
+}

--- a/frontend/src/pages/Personality.tsx
+++ b/frontend/src/pages/Personality.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { getDetailedFeature, DetailedFeatureInfo, Acronym, ComponentAcronym } from '../constants/officialFeatures';
 import { getVideoFileForCategory } from '../constants/videoMap';
+import { getPlaybackRateForCategory } from '../constants/videoPlayback';
 
 // Helper function to format finalKey for videoMap
 function formatKeyForVideo(finalKey: string | undefined): string {
@@ -82,15 +83,10 @@ const Personality: React.FC = () => {
         const videoMapKey = formatKeyForVideo(finalKey);
         const videoFileName = getVideoFileForCategory(videoMapKey);
         const newVideoSrc = videoFileName ? `/movie/${videoFileName}` : '/movie/default_poster.jpg';
-        setVideoSrc(newVideoSrc); // This line remains crucial
+        setVideoSrc(newVideoSrc);
 
-        // Determine target playback rate based on key
-        let rate = 1;
-        if (videoMapKey === 'MARI_ALPHA_2' || videoMapKey === 'SENRI_ALPHA_2') {
-          rate = 1.5;
-        } else if (videoMapKey === 'MARI_BETA_1') {
-          rate = 1.3;
-        }
+        // Determine target playback rate using utility
+        const rate = getPlaybackRateForCategory(finalKey);
         setPlaybackRate(rate);
       }
     }


### PR DESCRIPTION
## Summary
- centralize playback speed mapping for result videos
- use new helper in Personality page
- use new helper in DetailedQuestionnaire

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415ece2870832792a4073c07cba733